### PR TITLE
Two cases of listItem content

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -811,6 +811,9 @@ var tests = [
       // <li>
       //   <h3 id="item3">item3 some more in item3 header
       //     and some more item3 header content</h3>
+      //<pre>
+      //  illustrative();
+      //</pre>
       //   <p>item3 para1 some more item3 para1 and more item3
       //   para1</p>
       //   <p>item3 para2 item3 para2 more</p>


### PR DESCRIPTION
With a bit of thought, how should blocks inside lists behave?

Let us consider two simple cases of listItem content:
1. When there's nothing more in listItem except inline content:

```
   * something
```

 listItem translates to a simple `<li>something</li>`.
1. When there's one or more blocks following listItem inline content, like this:

```
     * item1
        %%hljs
          something();
        %%
```

or this:

```
      * item1

        item1 para2

        item1 para3
        %%hljs
          something();
        %%
      * item2
      * item3
```

First inline content gets wrapped into `para`, forming first block, and with all other blocks forms a list of children of listItem:

```
          ...
          ["ulistItem",
           [["para",["item1"]],
            ["para",["item1 para2"]],
            ["para",["item1 para3"]],
            ["extension","hljs","something();",""]]]
          ...
```

so the second case is effectively a list of block-level elements inside a listItem.
